### PR TITLE
Remove warden spells

### DIFF
--- a/Fury 51-60.xml
+++ b/Fury 51-60.xml
@@ -14,7 +14,6 @@
 <Setting Name="Ring of Fire (Expert)">1</Setting>
 <Setting Name="Autumn's Kiss IV (Expert)">1</Setting>
 <Setting Name="Untamed Regeneration IV (Expert)">1</Setting>
-<Setting Name="Winds of Healing IV (Expert)">1</Setting>
 <Setting Name="Abolishment II (Expert)">1</Setting>
 <Setting Name="Nature's Salve VII (Expert)">1</Setting>
 <Setting Name="Feast III (Expert)">1</Setting>
@@ -22,7 +21,6 @@
 <Setting Name="Lucidity V (Expert)">1</Setting>
 <Setting Name="Hibernation (Expert)">1</Setting>
 <Setting Name="Death Swarm VI (Expert)">1</Setting>
-<Setting Name="Dawnstrike VI (Expert)">1</Setting>
 <Setting Name="Nature's Elixir VI (Expert)">1</Setting>
 <Setting Name="Forest Spirit IV (Expert)">1</Setting>
 <Setting Name="Starnova III (Expert)">1</Setting>


### PR DESCRIPTION
WoH and Dawnstrike are warden.